### PR TITLE
Update Dockerfile per best-practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 
 FROM debian:buster-slim
 
-RUN apt update
-RUN apt install gcc make perl wget rsync --no-install-recommends -y
+RUN apt-get update && apt-get install -y gcc make perl wget rsync --no-install-recommends
 
 WORKDIR /alpine-mirror


### PR DESCRIPTION
See https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run

> Using apt-get update alone in a RUN statement causes caching issues and subsequent apt-get install instructions fail.